### PR TITLE
Adding Build Status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # HomeChecklist
+
+[![Build Status](https://codejanitor.dynu.net/jenkins/buildStatus/icon?job=HomeChecklist/master)](https://codejanitor.dynu.net/jenkins/job/HomeChecklist/master)


### PR DESCRIPTION
Even with the build/deploy being in such turmoil while I learn about Kubernetes, the status should still be available.